### PR TITLE
Handle 404s

### DIFF
--- a/lib/payments/client/gateway.rb
+++ b/lib/payments/client/gateway.rb
@@ -20,6 +20,8 @@ module Payments
               request.headers['Accept'] = 'application/json'
               request.headers["X-Request-Id"] = Payments::Client.request_id
             end
+          rescue Faraday::ResourceNotFound => e
+            Hashie::Mash.new(e.response)
           rescue Faraday::Error => e
             raise Payments::Client::Error.new(e.message)
           end

--- a/lib/payments/client/gateway.rb
+++ b/lib/payments/client/gateway.rb
@@ -17,6 +17,7 @@ module Payments
         define_method(verb) do |path, params = nil|
           begin
             connection.public_send(verb, prefix(path), params) do |request|
+              request.headers['Accept'] = 'application/json'
               request.headers["X-Request-Id"] = Payments::Client.request_id
             end
           rescue Faraday::Error => e

--- a/lib/payments/client/version.rb
+++ b/lib/payments/client/version.rb
@@ -1,5 +1,5 @@
 module Payments
   module Client
-    VERSION = "0.0.11"
+    VERSION = "0.0.12"
   end
 end


### PR DESCRIPTION
This ensures that Kanga now returns JSON when it 404s, and it also handles how Faraday treats it, and pass on the response.